### PR TITLE
Storage Request

### DIFF
--- a/src/filer.js
+++ b/src/filer.js
@@ -411,14 +411,13 @@ var Filer = new function() {
       opt_successCallback && opt_successCallback(fs);
     };
     
-    if (this.type==self.PERSISTENT)
+    if (this.type == self.PERSISTENT) {
       self.webkitStorageInfo.requestQuota(this.type, size, function(grantedBytes) {
-        self.requestFileSystem(this.type, size, init.bind(this), opt_errorHandler);
-      }.bind(this), function(e) {
-        opt_errorHandler && opt_errorHandler(e);
-      });
-    else
+        self.requestFileSystem(this.type, grantedBytes, init.bind(this), opt_errorHandler);
+      }.bind(this), opt_errorHandler);
+    } else {
       self.requestFileSystem(this.type, size, init.bind(this), opt_errorHandler);
+    }
   };
 
   /**


### PR DESCRIPTION
I extended the init-method to enable a storage request via the StorageInfo object. Therefore a user who is trying to initialize a instance of Filer with persistent storage for the first time will be asked for permission or receive an error to the error handler.
