### PR TITLE
Allow the installation of filer.js with npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+build/*
+demos/*
+tests/*
+src/filer.js
+component.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "filer.js",
+  "version": "0.4.3",
+  "main": "./src/filer.min.js"
+}


### PR DESCRIPTION
Hello,

I opt for allowing the installation of **filer.js** with **npm**.
This adds an standard `package.json` definition with the minimum required information according e840348b6f156f47c6261b0b10ead8488820c541, and a `.npmignore` file for the lighter possible installation.

This is only a suggestion for future use, I can always use my own fork, thanks for this excellent wrapper.